### PR TITLE
Domain decomposition for gravity

### DIFF
--- a/src/gridset.f90
+++ b/src/gridset.f90
@@ -28,12 +28,12 @@ subroutine gridset
              x2, xi2, dx2, dxi2, idx2, idxi2, &
              x3, xi3, dx3, dxi3, idx3, idxi3 )
   allocate( &
-   x1(gis-2:gie+2), xi1(gis-2:gie+2), dx1(gis-2:gie+2), dxi1(gis-2:gie+2), &
-   idx1(gis-2:gie+2), idxi1(gis-2:gie+2), &
-   x2(gjs-2:gje+2), xi2(gjs-2:gje+2), dx2(gjs-2:gje+2), dxi2(gjs-2:gje+2), &
-   idx2(gjs-2:gje+2), idxi2(gjs-2:gje+2), &
-   x3(gks-2:gke+2), xi3(gks-2:gke+2), dx3(gks-2:gke+2), dxi3(gks-2:gke+2), &
-   idx3(gks-2:gke+2), idxi3(gks-2:gke+2) &
+   x1(gis_global-2:gie_global+2), xi1(gis_global-2:gie_global+2), dx1(gis_global-2:gie_global+2), &
+   dxi1(gis_global-2:gie_global+2), idx1(gis_global-2:gie_global+2), idxi1(gis_global-2:gie_global+2), &
+   x2(gjs_global-2:gje_global+2), xi2(gjs_global-2:gje_global+2), dx2(gjs_global-2:gje_global+2), &
+   dxi2(gjs_global-2:gje_global+2), idx2(gjs_global-2:gje_global+2), idxi2(gjs_global-2:gje_global+2), &
+   x3(gks_global-2:gke_global+2), xi3(gks_global-2:gke_global+2), dx3(gks_global-2:gke_global+2), &
+   dxi3(gks_global-2:gke_global+2), idx3(gks_global-2:gke_global+2), idxi3(gks_global-2:gke_global+2) &
   )
  end if
 

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -24,6 +24,7 @@ module mpi_domain
    contains
 
    subroutine domain_decomp
+      use settings, only:gravswitch
       use grid
 #ifdef MPI
       integer :: nx, ny, nz
@@ -69,7 +70,8 @@ module mpi_domain
          n_tmp(axis) = n_tmp(axis) / real(factors(i))
       enddo
 
-      periods = [.true., .true., .true.] ! Always set to periodic and allow boundary conditions to override
+      ! Always set to periodic and allow boundary conditions to override
+      periods = [.true., .true., .true.] 
 
       call MPI_Cart_create(MPI_COMM_WORLD, 3, dims, periods, .false., cart_comm, ierr)
       call MPI_Cart_coords(cart_comm, myrank, 3, mycoords, ierr)
@@ -86,6 +88,36 @@ module mpi_domain
       if (mycoords(1) == dims(1) - 1) ie = nx + (is_global - 1)
       if (mycoords(2) == dims(2) - 1) je = ny + (js_global - 1)
       if (mycoords(3) == dims(3) - 1) ke = nz + (ks_global - 1)
+
+      ! Copy the hydro grid decomposition to the gravity grid
+      gis = is
+      gie = ie
+      gjs = js
+      gje = je
+      gks = ks
+      gke = ke
+
+      ! Check for gravity grid extension and adjust if necessary
+      if (gravswitch > 0) then
+         if (mycoords(1) == 0) then
+            if (gis_global /= is_global) gis = gis_global
+         endif
+         if (mycoords(1) == dims(1) - 1) then
+            if (gie_global /= ie_global) gie = gie_global
+         endif
+         if (mycoords(2) == 0) then
+            if (gjs_global /= js_global) gjs = gjs_global
+         endif
+         if (mycoords(2) == dims(2) - 1) then
+            if (gje_global /= je_global) gje = gje_global
+         endif
+         if (mycoords(3) == 0) then
+            if (gks_global /= ks_global) gks = gks_global
+         endif
+         if (mycoords(3) == dims(3) - 1) then
+            if (gke_global /= ke_global) gke = gke_global
+         endif
+      endif
 
       call setup_mpi_exchange
       call setup_mpi_io

--- a/src/mpi_domain.F90
+++ b/src/mpi_domain.F90
@@ -98,7 +98,7 @@ module mpi_domain
       gke = ke
 
       ! Check for gravity grid extension and adjust if necessary
-      if (gravswitch > 0) then
+      if (gravswitch >= 1) then
          if (mycoords(1) == 0) then
             if (gis_global /= is_global) gis = gis_global
          endif


### PR DESCRIPTION
Set the gravity indices `gis`, `gie`, ... the same as the hydro indices `is`, `ie`,... to ensure that the boundaries between MPI tasks are the same.

Where the physical start and end indices of the hydro and gravity grids and not the same, adjust the local indices to match the global indices.

For example, first set `gie = ie`. And then, on the last MPI task in this axis, if `gie_global /= ie_global`, set `gie = gie_global`.

This causes the end MPI tasks to potentially have more gravity cells. In cases where the gravity grid is significantly larger than the hydro grid, this can result in load imbalance.

Other changes:
- Refactor domain decomposition routine for readability